### PR TITLE
Redirect with new credentials when credentials have expired

### DIFF
--- a/lib/mtapes/playlists.ex
+++ b/lib/mtapes/playlists.ex
@@ -8,6 +8,8 @@ defmodule Mtapes.Playlists do
 
   alias Mtapes.Playlists.Playlist
 
+  require Logger
+
   @doc """
   Returns the list of playlist.
 
@@ -71,6 +73,8 @@ defmodule Mtapes.Playlists do
     playlist
     |> Playlist.changeset(attrs)
     |> Repo.update()
+
+    Logger.info(playlist.spotify_id)
   end
 
   @doc """

--- a/lib/mtapes_web/auth_plug.ex
+++ b/lib/mtapes_web/auth_plug.ex
@@ -1,5 +1,5 @@
 defmodule MtapesWeb.Plugs.Auth do
-  import Plug.Conn
+  require Logger
 
   def init(default), do: default
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Mtapes.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:pow, "~> 1.0.16"},
       {:pow_assent, "~> 0.4.5"},
-      {:spotify_ex, "~> 2.0.9"},
+      {:spotify_ex, "~> 2.0.9", path: 'deps/spotify_ex'},
       {:ssl_verify_fun, "~> 1.1"}
     ]
   end


### PR DESCRIPTION
As above, this should handle when the auth token expires without having to store the expiry time on the user object.

In the future, it may be desirable to store `expires_at` on the user object, though avoiding the DB call per request is also desirable.